### PR TITLE
feat: Show exact match first in sharing widget

### DIFF
--- a/ts/Common/Api.ts
+++ b/ts/Common/Api.ts
@@ -74,6 +74,11 @@ export interface ShareWith {
 	users: ShareWithOption[];
 	groups: ShareWithOption[];
 	circles: ShareWithOption[];
+	exact: {
+		users: ShareWithOption[];
+		groups: ShareWithOption[];
+		circles: ShareWithOption[];
+	}
 }
 
 class Api {
@@ -239,9 +244,14 @@ class Api {
 		});
 
 		return {
-			users: response.data.ocs.data.exact.users,
-			groups: response.data.ocs.data.exact.groups,
-			circles: response.data.ocs.data.exact.circles || [],
+			users: [],
+			groups: [],
+			circles: [],
+			exact: {
+			       users: response.data.ocs.data.exact.users,
+			       groups: response.data.ocs.data.exact.groups,
+			       circles: response.data.ocs.data.exact.circles || [],
+			},
 		};
 	}
 
@@ -260,9 +270,14 @@ class Api {
 		const data = response.data.ocs.data;
 
 		return {
-			users: [...data.users, ...data.exact.users],
-			groups: [...data.groups, ...data.exact.groups],
-			circles: [...(data.circles || []), ...(data.exact.circles || [])],
+			users: data.users,
+			groups: data.groups,
+			circles: data.circles || [],
+			exact: {
+				users: data.exact.users,
+				groups: data.exact.groups,
+				circles: data.exact.circles || [],
+			},
 		};
 	}
 }

--- a/ts/Common/ShareSelection.tsx
+++ b/ts/Common/ShareSelection.tsx
@@ -63,6 +63,9 @@ const ShareSelection: React.FC<Props> = (props) => {
 
 	function renderSearchResults(options: ShareWith|undefined) {
 		const results = options ? [
+			...options.exact.users.filter(user => !excluded.userIds.includes(user.value.shareWith)),
+			...options.exact.groups.filter(group => !excluded.groupIds.includes(group.value.shareWith)),
+			...options.exact.circles.filter(circle => !excluded.circleIds.includes(circle.value.shareWith)),
 			...options.users.filter(user => !excluded.userIds.includes(user.value.shareWith)),
 			...options.groups.filter(group => !excluded.groupIds.includes(group.value.shareWith)),
 			...options.circles.filter(circle => !excluded.circleIds.includes(circle.value.shareWith)),


### PR DESCRIPTION
*Problem*

1. Nextcloud is used inside an organisation where most people share the same mail domain
2. A Nextcloud group exists which matches parts of the mail domain
3. An attempt is made to add the group in the sharing widget

In this case the sharing widget shows all matching users (i.e., all users) before the group.

*Solution*

Show exact matches at the top.