### PR TITLE
Add Scalelite documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,8 @@ for details.
   - copy the location of the share from the share information screen into your clipboard
   - open big blue button, press the plus icon in the lower left corner
   - click on add external video
-  - paste the url from your clipboard and append the following string for audio `/download/file.mp3` or `/download/file.mp4` for video files
+  - paste the url from your clipboard and append the following string for audio `/download?.mp3` or `/download?.mp4` for video files
+- For connecting to a ScaleLite Server use the url like https://yourscalelite.url/bigbluebutton/ without additional api/ and for secret scalelite's LOADBALANCER_SECRET  
 
 ## :heart: Sponsors
 Writing such an application is a lot of work and therefore we are specially


### PR DESCRIPTION
Original author @spreeni151: Adding a comment to troubleshooting section because ScaleLite documentation gives different advices for Scalelite server integration. Changed the adress of shared audio or video to the more usable and common '/download?.mp3' and '/download?.mp4'