### PR TITLE
feat: add admin settings for default skip media

### DIFF
--- a/lib/Service/RoomService.php
+++ b/lib/Service/RoomService.php
@@ -82,7 +82,7 @@ class RoomService {
 	public function create(string $name, string $welcome, int $maxParticipants, bool $record, string $access, string $userId): \OCP\AppFramework\Db\Entity {
 		$room = new Room();
 
-		$mediaCheck = $this->config->getAppValue('bbb', 'join.mediaCheck') !== 'true';
+		$mediaCheck = $this->config->getAppValue('bbb', 'join.mediaCheck') === 'true';
 
 		$room->setUid(\OC::$server->getSecureRandom()->generate(16, \OCP\Security\ISecureRandom::CHAR_HUMAN_READABLE));
 		$room->setName($name);

--- a/lib/Service/RoomService.php
+++ b/lib/Service/RoomService.php
@@ -82,11 +82,7 @@ class RoomService {
 	public function create(string $name, string $welcome, int $maxParticipants, bool $record, string $access, string $userId): \OCP\AppFramework\Db\Entity {
 		$room = new Room();
 
-		if($this->config->getAppValue('bbb', 'join.defaultMedia') === 'true') {
-			$media = false;
-		} else {
-			$media = true;
-		}
+		$mediaCheck = $this->config->getAppValue('bbb', 'join.mediaCheck') !== 'true';
 
 		$room->setUid(\OC::$server->getSecureRandom()->generate(16, \OCP\Security\ISecureRandom::CHAR_HUMAN_READABLE));
 		$room->setName($name);

--- a/lib/Service/RoomService.php
+++ b/lib/Service/RoomService.php
@@ -94,7 +94,7 @@ class RoomService {
 		$room->setAccess($access);
 		$room->setUserId($userId);
 		$room->setListenOnly(true);
-		$room->setMediaCheck($media);
+		$room->setMediaCheck($mediaCheck);
 		$room->setCleanLayout(false);
 		$room->setJoinMuted(false);
 

--- a/lib/Service/RoomService.php
+++ b/lib/Service/RoomService.php
@@ -12,19 +12,25 @@ use OCA\BigBlueButton\Event\RoomDeletedEvent;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Db\MultipleObjectsReturnedException;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\IConfig;
 
 class RoomService {
 
 	/** @var RoomMapper */
 	private $mapper;
 
+	/** @var IConfig */
+	private $config;
+
 	/** @var IEventDispatcher */
 	private $eventDispatcher;
 
 	public function __construct(
 		RoomMapper $mapper,
+		IConfig $config,
 		IEventDispatcher $eventDispatcher) {
 		$this->mapper = $mapper;
+		$this->config = $config;
 		$this->eventDispatcher = $eventDispatcher;
 	}
 
@@ -76,6 +82,12 @@ class RoomService {
 	public function create(string $name, string $welcome, int $maxParticipants, bool $record, string $access, string $userId): \OCP\AppFramework\Db\Entity {
 		$room = new Room();
 
+		if($this->config->getAppValue('bbb', 'join.defaultMedia') === 'true') {
+			$media = false;
+		} else {
+			$media = true;
+		}
+
 		$room->setUid(\OC::$server->getSecureRandom()->generate(16, \OCP\Security\ISecureRandom::CHAR_HUMAN_READABLE));
 		$room->setName($name);
 		$room->setWelcome($welcome);
@@ -86,7 +98,7 @@ class RoomService {
 		$room->setAccess($access);
 		$room->setUserId($userId);
 		$room->setListenOnly(true);
-		$room->setMediaCheck(true);
+		$room->setMediaCheck($media);
 		$room->setCleanLayout(false);
 		$room->setJoinMuted(false);
 

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -30,6 +30,7 @@ class Admin implements ISettings {
 			'app.navigation' => $this->config->getAppValue('bbb', 'app.navigation') === 'true' ? 'checked' : '',
 			'join.theme' => $this->config->getAppValue('bbb', 'join.theme') === 'true' ? 'checked' : '',
 			'app.shortener' => $this->config->getAppValue('bbb', 'app.shortener'),
+			'join.defaultMedia' => $this->config->getAppValue('bbb', 'join.defaultMedia') === 'true' ? 'checked' : '',
 		];
 
 		return new TemplateResponse('bbb', 'admin', $parameters);

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -30,7 +30,7 @@ class Admin implements ISettings {
 			'app.navigation' => $this->config->getAppValue('bbb', 'app.navigation') === 'true' ? 'checked' : '',
 			'join.theme' => $this->config->getAppValue('bbb', 'join.theme') === 'true' ? 'checked' : '',
 			'app.shortener' => $this->config->getAppValue('bbb', 'app.shortener'),
-			'join.defaultMedia' => $this->config->getAppValue('bbb', 'join.defaultMedia') === 'true' ? 'checked' : '',
+			'join.mediaCheck' => $this->config->getAppValue('bbb', 'join.mediaCheck') === 'true' ? 'checked' : '',
 		];
 
 		return new TemplateResponse('bbb', 'admin', $parameters);

--- a/templates/admin.php
+++ b/templates/admin.php
@@ -34,7 +34,7 @@ script('bbb', 'restrictions');
 
         <p>
             <input type="checkbox" name="join.mediaCheck" id="bbb-join-mediaCheck" class="checkbox bbb-setting" value="1" <?php p($_['join.mediaCheck']); ?> />
-            <label for="bbb-join-mediaCheck"><?php p($l->t('Skip media check before usage')); ?></label>
+            <label for="bbb-join-mediaCheck"><?php p($l->t('Perform media check before usage')); ?></label>
         </p>
 
         <h3><?php p($l->t('Community')); ?></h3>

--- a/templates/admin.php
+++ b/templates/admin.php
@@ -29,6 +29,14 @@ script('bbb', 'restrictions');
             <label for="bbb-join-theme"><?php p($l->t('Use Nextcloud theme in BigBlueButton.')); ?></label>
         </p>
 
+        <h3><?php p($l->t('Default Room Settings')); ?></h3>
+        <p><?php p($l->t('Below you can change some default values, which are used to create a new room.')); ?></p>
+
+        <p>
+            <input type="checkbox" name="join.defaultMedia" id="bbb-join-defaultMedia" class="checkbox bbb-setting" value="1" <?php p($_['join.defaultMedia']); ?> />
+            <label for="bbb-join-defaultMedia"><?php p($l->t('Skip media check before usage')); ?></label>
+        </p>
+
         <h3><?php p($l->t('Community')); ?></h3>
         <p><?php p($l->t('Are you enjoying this app? Give something back to the open source community.')); ?> <a href="https://github.com/sualko/cloud_bbb/blob/master/.github/contributing.md" target="_blank" rel="noopener noreferrer" class="button"><span class="heart"></span> <?php p($l->t('Checkout the contributor guide')); ?></a></p>
 

--- a/templates/admin.php
+++ b/templates/admin.php
@@ -33,8 +33,8 @@ script('bbb', 'restrictions');
         <p><?php p($l->t('Below you can change some default values, which are used to create a new room.')); ?></p>
 
         <p>
-            <input type="checkbox" name="join.defaultMedia" id="bbb-join-defaultMedia" class="checkbox bbb-setting" value="1" <?php p($_['join.defaultMedia']); ?> />
-            <label for="bbb-join-defaultMedia"><?php p($l->t('Skip media check before usage')); ?></label>
+            <input type="checkbox" name="join.mediaCheck" id="bbb-join-mediaCheck" class="checkbox bbb-setting" value="1" <?php p($_['join.mediaCheck']); ?> />
+            <label for="bbb-join-mediaCheck"><?php p($l->t('Skip media check before usage')); ?></label>
         </p>
 
         <h3><?php p($l->t('Community')); ?></h3>


### PR DESCRIPTION
The feature adds the option for admins to set a default value for the "skip media check" at room creation. The feature can be found unter the admin settings - other default settings can be implemented there too.
