### PR TITLE
Add support for meta parameter "analytics-callback-url"

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,13 @@ Key                               | Description
 `app.shortener`                   | Value of your shortener service. Should start with `https://` and contain `{token}`.
 `avatar.path`                     | Absolute path to an optional avatar cache directory.
 `avatar.url`                      | URL which serves `avatar.path` to be used as avatar cache.
-`api.meta_analytics-callback-url` | URL which gets called after meetings ends to generate statistics.
+
+
+Extra parameter not setable in web interface
+
+Key                               | Description
+--------------------------------- | ----------------------------------------------------------------------------------------------------------------
+`api.meta_analytics-callback-url` |  URL which gets called after meetings ends to generate statistics. See https://github.com/betagouv/bbb-analytics
 
 ### Avatar cache (v2.2+)
 The generation of avatars puts a high load on your Nextcloud instance, since the

--- a/README.md
+++ b/README.md
@@ -69,15 +69,16 @@ used configuration keys in the list below. Please beware that there will be no
 check if those values are correct. Therefore this is not the recommended way.
 The syntax to set all settings is `occ config:app:set bbb KEY --value "VALUE"`.
 
-Key                   | Description
---------------------- | ------------------------------------------------------------------------------------
-`app.navigation`      | Set to `true` to show navigation entry
-`app.navigation.name` | Defines the navigation label. Default "BigBlueButton".
-`api.url`             | URL to your BBB server. Should start with `https://`
-`api.secret`          | Secret of your BBB server
-`app.shortener`       | Value of your shortener service. Should start with `https://` and contain `{token}`.
-`avatar.path`         | Absolute path to an optional avatar cache directory.
-`avatar.url`          | URL which serves `avatar.path` to be used as avatar cache.
+Key                               | Description
+--------------------------------- | ------------------------------------------------------------------------------------
+`app.navigation`                  | Set to `true` to show navigation entry
+`app.navigation.name`             | Defines the navigation label. Default "BigBlueButton".
+`api.url`                         | URL to your BBB server. Should start with `https://`
+`api.secret`                      | Secret of your BBB server
+`app.shortener`                   | Value of your shortener service. Should start with `https://` and contain `{token}`.
+`avatar.path`                     | Absolute path to an optional avatar cache directory.
+`avatar.url`                      | URL which serves `avatar.path` to be used as avatar cache.
+`api.meta_analytics-callback-url` | URL which gets called after meetings ends to generate statistics.
 
 ### Avatar cache (v2.2+)
 The generation of avatars puts a high load on your Nextcloud instance, since the

--- a/lib/BigBlueButton/API.php
+++ b/lib/BigBlueButton/API.php
@@ -176,7 +176,8 @@ class API {
 		$createMeetingParams->addMeta('bbb-origin-server-name', $this->request->getServerHost());
 		
 		if (!empty($this->config->getAppValue('bbb', 'api.meta_analytics-callback-url'))) {
-		      $createMeetingParams->addMeta('analytics-callback-url', $this->config->getAppValue('bbb', 'api.meta_analytics-callback-url'));
+			$createMeetingParams->addMeta('analytics-callback-url', $this->config->getAppValue('bbb', 'api.meta_analytics-callback-url'));
+			$createMeetingParams->setMeetingKeepEvents(true);
 		}
 
 		$mac = $this->crypto->calculateHMAC($room->uid);

--- a/lib/BigBlueButton/API.php
+++ b/lib/BigBlueButton/API.php
@@ -175,8 +175,8 @@ class API {
 		$createMeetingParams->addMeta('bbb-origin', \method_exists($this->defaults, 'getProductName') ? $this->defaults->getProductName() : 'Nextcloud');
 		$createMeetingParams->addMeta('bbb-origin-server-name', $this->request->getServerHost());
 		
-		if (!empty($this->config->getAppValue('bbb', 'api.meta_analytics-callback-url')) {
-		      $createMeetingParams->addMeta('analytics-callback-url', \urlencode($this->config->getAppValue('bbb', 'api.meta_analytics-callback-url')));
+		if (!empty($this->config->getAppValue('bbb', 'api.meta_analytics-callback-url'))) {
+		      $createMeetingParams->addMeta('analytics-callback-url', $this->config->getAppValue('bbb', 'api.meta_analytics-callback-url'));
 		}
 
 		$mac = $this->crypto->calculateHMAC($room->uid);

--- a/lib/BigBlueButton/API.php
+++ b/lib/BigBlueButton/API.php
@@ -174,6 +174,10 @@ class API {
 		$createMeetingParams->addMeta('bbb-origin-version', $this->appManager->getAppVersion(Application::ID));
 		$createMeetingParams->addMeta('bbb-origin', \method_exists($this->defaults, 'getProductName') ? $this->defaults->getProductName() : 'Nextcloud');
 		$createMeetingParams->addMeta('bbb-origin-server-name', $this->request->getServerHost());
+		
+		if (!empty($this->config->getAppValue('bbb', 'api.meta_analytics-callback-url')) {
+		      $createMeetingParams->addMeta('analytics-callback-url', \urlencode($this->config->getAppValue('bbb', 'api.meta_analytics-callback-url')));
+		}
 
 		$mac = $this->crypto->calculateHMAC($room->uid);
 


### PR DESCRIPTION
This PR adds support for API parameter "meta_analytics-callback-url" which allows statistics generation on an external server.

A new parameter is added to the meeting creation call query string. It is a URL pointing to an external analytics generation service. Meeting's `events.xml` file gets posted to this URL after meeting ends. A second parameter is added to the query string to force BBB server to keep `events.xml` in all cases. This makes use of a standard BBB post_events script as referenced here : https://github.com/bigbluebutton/bigbluebutton/blob/develop/record-and-playback/core/scripts/post_events/post_events_analytics_callback.rb

To enable this feature, administrators must add the config parameter "api.meta_analytics-callback-url" by means of "occ" command : e.g.
`occ config:app:set bbb "api.meta_analytics-callback-url" --value "https://stats-server.example.com/v1/post_events"