### PR TITLE
Fix composer lock and static analysis after updating nextcloud/ocp

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -21,7 +21,7 @@ jobs:
         - name: Install dependencies
           run: composer i
         - name: Install dependencies
-          run: composer require --dev nextcloud/ocp:${{ matrix.ocp-version }}
+          run: composer require --dev nextcloud/ocp:${{ matrix.ocp-version }} psr/container symfony/service-contracts
         - name: Run coding standards check
           run: composer run psalm
 

--- a/composer.lock
+++ b/composer.lock
@@ -1191,16 +1191,16 @@
         },
         {
             "name": "nextcloud/ocp",
-            "version": "v24.0.1",
+            "version": "v26.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "f032acdff1502a7323f95a6524d163290f43b446"
+                "reference": "6f0ffec5ace13e71f50d0735c0258fc37f4ca562"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/f032acdff1502a7323f95a6524d163290f43b446",
-                "reference": "f032acdff1502a7323f95a6524d163290f43b446",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/6f0ffec5ace13e71f50d0735c0258fc37f4ca562",
+                "reference": "6f0ffec5ace13e71f50d0735c0258fc37f4ca562",
                 "shasum": ""
             },
             "require": {
@@ -1212,7 +1212,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "24.0.0-dev"
+                    "dev-master": "26.0.0-dev"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1227,9 +1227,10 @@
             ],
             "description": "Composer package containing Nextcloud's public API (classes, interfaces)",
             "support": {
-                "source": "https://github.com/nextcloud-deps/ocp/tree/v24.0.1"
+                "issues": "https://github.com/nextcloud-deps/ocp/issues",
+                "source": "https://github.com/nextcloud-deps/ocp/tree/v26.0.4"
             },
-            "time": "2022-06-02T14:16:47+00:00"
+            "time": "2023-07-17T09:26:46+00:00"
         },
         {
             "name": "nikic/php-parser",


### PR DESCRIPTION
Nextcloud 27 depends on `psr/container=^2`. Thus, we need to allow upgrading to this version for static analysis.