### PR TITLE
fix: rephrase share notice (#250)

### DIFF
--- a/l10n/ar.js
+++ b/l10n/ar.js
@@ -115,7 +115,7 @@ OC.L10N.register(
     "admin" : "مشرف",
     "Share" : "شارك",
     "Loading" : "Loading",
-    "You are not allowed to change this option, because this room is shared with you." : "لا يمكنك تعديل هذا الخيار؛ بسبب أن الغرفة مشاركة معك.",
+    "You are not allowed to share this room further, because this room is shared with you." : "لا يمكنك تعديل هذا الخيار؛ بسبب أن الغرفة مشاركة معك.",
     "Max. rooms" : "أقصى عدد من الغرف",
     "Max. participants" : "أقصى عدد من المشاركين",
     "Group …" : "المجموعات ...",

--- a/l10n/ar.json
+++ b/l10n/ar.json
@@ -113,7 +113,7 @@
     "admin" : "مشرف",
     "Share" : "شارك",
     "Loading" : "Loading",
-    "You are not allowed to change this option, because this room is shared with you." : "لا يمكنك تعديل هذا الخيار؛ بسبب أن الغرفة مشاركة معك.",
+    "You are not allowed to share this room further, because this room is shared with you." : "لا يمكنك تعديل هذا الخيار؛ بسبب أن الغرفة مشاركة معك.",
     "Max. rooms" : "أقصى عدد من الغرف",
     "Max. participants" : "أقصى عدد من المشاركين",
     "Group …" : "المجموعات ...",

--- a/l10n/bg.js
+++ b/l10n/bg.js
@@ -115,7 +115,7 @@ OC.L10N.register(
     "admin" : "администратор",
     "Share" : "Сподели",
     "Loading" : "Зареждане",
-    "You are not allowed to change this option, because this room is shared with you." : "Нямате право да променяте тази опция, защото тази стая е споделена с вас.",
+    "You are not allowed to share this room further, because this room is shared with you." : "Нямате право да променяте тази опция, защото тази стая е споделена с вас.",
     "Max. rooms" : "Макс. стаи",
     "Max. participants" : "Макс. участници ",
     "Group …" : "Група ...",

--- a/l10n/bg.json
+++ b/l10n/bg.json
@@ -113,7 +113,7 @@
     "admin" : "администратор",
     "Share" : "Сподели",
     "Loading" : "Зареждане",
-    "You are not allowed to change this option, because this room is shared with you." : "Нямате право да променяте тази опция, защото тази стая е споделена с вас.",
+    "You are not allowed to share this room further, because this room is shared with you." : "Нямате право да променяте тази опция, защото тази стая е споделена с вас.",
     "Max. rooms" : "Макс. стаи",
     "Max. participants" : "Макс. участници ",
     "Group …" : "Група ...",

--- a/l10n/ca.js
+++ b/l10n/ca.js
@@ -115,7 +115,7 @@ OC.L10N.register(
     "admin" : "administrador",
     "Share" : "Compartir",
     "Loading" : "Carregant",
-    "You are not allowed to change this option, because this room is shared with you." : "No podeu canviar aquesta opció perquè aquesta sala es comparteix amb vostè.",
+    "You are not allowed to share this room further, because this room is shared with you." : "No podeu canviar aquesta opció perquè aquesta sala es comparteix amb vostè.",
     "Max. rooms" : "Màx. sales",
     "Max. participants" : "Màx. participants",
     "Group …" : "Grup …",

--- a/l10n/ca.json
+++ b/l10n/ca.json
@@ -113,7 +113,7 @@
     "admin" : "administrador",
     "Share" : "Compartir",
     "Loading" : "Carregant",
-    "You are not allowed to change this option, because this room is shared with you." : "No podeu canviar aquesta opció perquè aquesta sala es comparteix amb vostè.",
+    "You are not allowed to share this room further, because this room is shared with you." : "No podeu canviar aquesta opció perquè aquesta sala es comparteix amb vostè.",
     "Max. rooms" : "Màx. sales",
     "Max. participants" : "Màx. participants",
     "Group …" : "Grup …",

--- a/l10n/cs.js
+++ b/l10n/cs.js
@@ -115,7 +115,7 @@ OC.L10N.register(
     "admin" : "správce",
     "Share" : "Sdílet",
     "Loading" : "Načítání",
-    "You are not allowed to change this option, because this room is shared with you." : "Nemáte oprávnění měnit tuto volbu, protože tato místnost je vám jen nasdílena.",
+    "You are not allowed to share this room further, because this room is shared with you." : "Nemáte oprávnění měnit tuto volbu, protože tato místnost je vám jen nasdílena.",
     "Max. rooms" : "Nejvýše místností",
     "Max. participants" : "Nejvýše účastníků",
     "Group …" : "Skupina…",

--- a/l10n/cs.json
+++ b/l10n/cs.json
@@ -113,7 +113,7 @@
     "admin" : "správce",
     "Share" : "Sdílet",
     "Loading" : "Načítání",
-    "You are not allowed to change this option, because this room is shared with you." : "Nemáte oprávnění měnit tuto volbu, protože tato místnost je vám jen nasdílena.",
+    "You are not allowed to share this room further, because this room is shared with you." : "Nemáte oprávnění měnit tuto volbu, protože tato místnost je vám jen nasdílena.",
     "Max. rooms" : "Nejvýše místností",
     "Max. participants" : "Nejvýše účastníků",
     "Group …" : "Skupina…",

--- a/l10n/de.js
+++ b/l10n/de.js
@@ -115,7 +115,7 @@ OC.L10N.register(
     "admin" : "Administrator",
     "Share" : "Teilen",
     "Loading" : "Lade",
-    "You are not allowed to change this option, because this room is shared with you." : "Du bist nicht berechtigt, diese Einstellung zu ändern, da dieser Raum mit dir geteilt wurde.",
+    "You are not allowed to share this room further, because this room is shared with you." : "Du bist nicht berechtigt, diesen Raum weiter zu teilen, da dieser Raum mit dir geteilt wurde.",
     "Max. rooms" : "Max. Räume",
     "Max. participants" : "Max. Teilnehmer",
     "Group …" : "Gruppe …",

--- a/l10n/de.json
+++ b/l10n/de.json
@@ -113,7 +113,7 @@
     "admin" : "Administrator",
     "Share" : "Teilen",
     "Loading" : "Lade",
-    "You are not allowed to change this option, because this room is shared with you." : "Du bist nicht berechtigt, diese Einstellung zu ändern, da dieser Raum mit dir geteilt wurde.",
+    "You are not allowed to share this room further, because this room is shared with you." : "Du bist nicht berechtigt, diesen Raum weiter zu teilen, da dieser Raum mit dir geteilt wurde.",
     "Max. rooms" : "Max. Räume",
     "Max. participants" : "Max. Teilnehmer",
     "Group …" : "Gruppe …",

--- a/l10n/de_DE.js
+++ b/l10n/de_DE.js
@@ -115,7 +115,7 @@ OC.L10N.register(
     "admin" : "Administrator",
     "Share" : "Teilen",
     "Loading" : "Lade",
-    "You are not allowed to change this option, because this room is shared with you." : "Sie können diese Einstellung nicht ändern, da dieser Raum mit Ihnen geteilt wurde.",
+    "You are not allowed to share this room further, because this room is shared with you." : "Sie können diesen Raum nicht weiter teilen, da dieser Raum mit Ihnen geteilt wurde.",
     "Max. rooms" : "Max. Räume",
     "Max. participants" : "Max. Teilnehmer",
     "Group …" : "Gruppe …",

--- a/l10n/de_DE.json
+++ b/l10n/de_DE.json
@@ -113,7 +113,7 @@
     "admin" : "Administrator",
     "Share" : "Teilen",
     "Loading" : "Lade",
-    "You are not allowed to change this option, because this room is shared with you." : "Sie können diese Einstellung nicht ändern, da dieser Raum mit Ihnen geteilt wurde.",
+    "You are not allowed to share this room further, because this room is shared with you." : "Sie können diesen Raum nicht weiter teilen, da dieser Raum mit Ihnen geteilt wurde.",
     "Max. rooms" : "Max. Räume",
     "Max. participants" : "Max. Teilnehmer",
     "Group …" : "Gruppe …",

--- a/l10n/el.js
+++ b/l10n/el.js
@@ -96,7 +96,7 @@ OC.L10N.register(
     "admin" : "διαχειριστής",
     "Share" : "Κοινή χρήση",
     "Loading" : "Γίνεται φόρτωση",
-    "You are not allowed to change this option, because this room is shared with you." : "Δεν επιτρέπεται να αλλάξετε αυτήν την επιλογή, επειδή αυτό το δωμάτιο είναι κοινόχρηστο μαζί σας.",
+    "You are not allowed to share this room further, because this room is shared with you." : "Δεν επιτρέπεται να αλλάξετε αυτήν την επιλογή, επειδή αυτό το δωμάτιο είναι κοινόχρηστο μαζί σας.",
     "Max. rooms" : "Μέγιστα δωμάτια",
     "Max. participants" : "Μέγιστος αριθμός συμμετεχόντων",
     "Group …" : "Ομάδα...",

--- a/l10n/el.json
+++ b/l10n/el.json
@@ -94,7 +94,7 @@
     "admin" : "διαχειριστής",
     "Share" : "Κοινή χρήση",
     "Loading" : "Γίνεται φόρτωση",
-    "You are not allowed to change this option, because this room is shared with you." : "Δεν επιτρέπεται να αλλάξετε αυτήν την επιλογή, επειδή αυτό το δωμάτιο είναι κοινόχρηστο μαζί σας.",
+    "You are not allowed to share this room further, because this room is shared with you." : "Δεν επιτρέπεται να αλλάξετε αυτήν την επιλογή, επειδή αυτό το δωμάτιο είναι κοινόχρηστο μαζί σας.",
     "Max. rooms" : "Μέγιστα δωμάτια",
     "Max. participants" : "Μέγιστος αριθμός συμμετεχόντων",
     "Group …" : "Ομάδα...",

--- a/l10n/en_GB.js
+++ b/l10n/en_GB.js
@@ -115,7 +115,7 @@ OC.L10N.register(
     "admin" : "admin",
     "Share" : "Share",
     "Loading" : "Loading",
-    "You are not allowed to change this option, because this room is shared with you." : "You are not allowed to change this option, because this room is shared with you.",
+    "You are not allowed to share this room further, because this room is shared with you." : "You are not allowed to share this room further, because this room is shared with you.",
     "Max. rooms" : "Max. rooms",
     "Max. participants" : "Max. participants",
     "Group …" : "Group …",

--- a/l10n/en_GB.json
+++ b/l10n/en_GB.json
@@ -113,7 +113,7 @@
     "admin" : "admin",
     "Share" : "Share",
     "Loading" : "Loading",
-    "You are not allowed to change this option, because this room is shared with you." : "You are not allowed to change this option, because this room is shared with you.",
+    "You are not allowed to share this room further, because this room is shared with you." : "You are not allowed to share this room further, because this room is shared with you.",
     "Max. rooms" : "Max. rooms",
     "Max. participants" : "Max. participants",
     "Group …" : "Group …",

--- a/l10n/es.js
+++ b/l10n/es.js
@@ -115,7 +115,7 @@ OC.L10N.register(
     "admin" : "administrador",
     "Share" : "Compartir",
     "Loading" : "Cargando",
-    "You are not allowed to change this option, because this room is shared with you." : "No puedes cambiar esta opción ya que esta sala está compartida contigo.",
+    "You are not allowed to share this room further, because this room is shared with you." : "No puedes cambiar esta opción ya que esta sala está compartida contigo.",
     "Max. rooms" : "Máximo de salas",
     "Max. participants" : "Máximo de participantes",
     "Group …" : "Grupo …",

--- a/l10n/es.json
+++ b/l10n/es.json
@@ -113,7 +113,7 @@
     "admin" : "administrador",
     "Share" : "Compartir",
     "Loading" : "Cargando",
-    "You are not allowed to change this option, because this room is shared with you." : "No puedes cambiar esta opción ya que esta sala está compartida contigo.",
+    "You are not allowed to share this room further, because this room is shared with you." : "No puedes cambiar esta opción ya que esta sala está compartida contigo.",
     "Max. rooms" : "Máximo de salas",
     "Max. participants" : "Máximo de participantes",
     "Group …" : "Grupo …",

--- a/l10n/es_EC.js
+++ b/l10n/es_EC.js
@@ -115,7 +115,7 @@ OC.L10N.register(
     "admin" : "admin",
     "Share" : "Compartir",
     "Loading" : "Cargando",
-    "You are not allowed to change this option, because this room is shared with you." : "No tienes permitido cambiar esta opción porque esta sala se comparte contigo.",
+    "You are not allowed to share this room further, because this room is shared with you." : "No tienes permitido cambiar esta opción porque esta sala se comparte contigo.",
     "Max. rooms" : "Máx. salas",
     "Max. participants" : "Máx. participantes",
     "Group …" : "Grupo...",

--- a/l10n/es_EC.json
+++ b/l10n/es_EC.json
@@ -113,7 +113,7 @@
     "admin" : "admin",
     "Share" : "Compartir",
     "Loading" : "Cargando",
-    "You are not allowed to change this option, because this room is shared with you." : "No tienes permitido cambiar esta opción porque esta sala se comparte contigo.",
+    "You are not allowed to share this room further, because this room is shared with you." : "No tienes permitido cambiar esta opción porque esta sala se comparte contigo.",
     "Max. rooms" : "Máx. salas",
     "Max. participants" : "Máx. participantes",
     "Group …" : "Grupo...",

--- a/l10n/eu.js
+++ b/l10n/eu.js
@@ -115,7 +115,7 @@ OC.L10N.register(
     "admin" : "admin",
     "Share" : "Partekatu",
     "Loading" : "Kargatzen",
-    "You are not allowed to change this option, because this room is shared with you." : "Ez duzu baimenik aukera hau aldatzeko, gela hau zurekin partekatua delako.",
+    "You are not allowed to share this room further, because this room is shared with you." : "Ez duzu baimenik aukera hau aldatzeko, gela hau zurekin partekatua delako.",
     "Max. rooms" : "Gela max.",
     "Max. participants" : "Parte-hartzaile max.",
     "Group …" : "Taldea ...",

--- a/l10n/eu.json
+++ b/l10n/eu.json
@@ -113,7 +113,7 @@
     "admin" : "admin",
     "Share" : "Partekatu",
     "Loading" : "Kargatzen",
-    "You are not allowed to change this option, because this room is shared with you." : "Ez duzu baimenik aukera hau aldatzeko, gela hau zurekin partekatua delako.",
+    "You are not allowed to share this room further, because this room is shared with you." : "Ez duzu baimenik aukera hau aldatzeko, gela hau zurekin partekatua delako.",
     "Max. rooms" : "Gela max.",
     "Max. participants" : "Parte-hartzaile max.",
     "Group …" : "Taldea ...",

--- a/l10n/fr.js
+++ b/l10n/fr.js
@@ -115,7 +115,7 @@ OC.L10N.register(
     "admin" : "administration",
     "Share" : "Partager",
     "Loading" : "Chargement",
-    "You are not allowed to change this option, because this room is shared with you." : "Vous n'êtes pas autorisé à changer cette option car cette salle est partagée avec vous.",
+    "You are not allowed to share this room further, because this room is shared with you." : "Vous n'êtes pas autorisé à changer cette option car cette salle est partagée avec vous.",
     "Max. rooms" : "Salles max.",
     "Max. participants" : "Nombre maximum de participants",
     "Group …" : "Groupe …",

--- a/l10n/fr.json
+++ b/l10n/fr.json
@@ -113,7 +113,7 @@
     "admin" : "administration",
     "Share" : "Partager",
     "Loading" : "Chargement",
-    "You are not allowed to change this option, because this room is shared with you." : "Vous n'êtes pas autorisé à changer cette option car cette salle est partagée avec vous.",
+    "You are not allowed to share this room further, because this room is shared with you." : "Vous n'êtes pas autorisé à changer cette option car cette salle est partagée avec vous.",
     "Max. rooms" : "Salles max.",
     "Max. participants" : "Nombre maximum de participants",
     "Group …" : "Groupe …",

--- a/l10n/gl.js
+++ b/l10n/gl.js
@@ -115,7 +115,7 @@ OC.L10N.register(
     "admin" : "admin",
     "Share" : "Compartir",
     "Loading" : "Cargando",
-    "You are not allowed to change this option, because this room is shared with you." : "Non ten permiso para cambiar esta opción, porque esta é unha sala compartida con Vde.",
+    "You are not allowed to share this room further, because this room is shared with you." : "Non ten permiso para cambiar esta opción, porque esta é unha sala compartida con Vde.",
     "Max. rooms" : "Máx. de salas",
     "Max. participants" : "Máx. de participantes",
     "Group …" : "Grupo…",

--- a/l10n/gl.json
+++ b/l10n/gl.json
@@ -113,7 +113,7 @@
     "admin" : "admin",
     "Share" : "Compartir",
     "Loading" : "Cargando",
-    "You are not allowed to change this option, because this room is shared with you." : "Non ten permiso para cambiar esta opción, porque esta é unha sala compartida con Vde.",
+    "You are not allowed to share this room further, because this room is shared with you." : "Non ten permiso para cambiar esta opción, porque esta é unha sala compartida con Vde.",
     "Max. rooms" : "Máx. de salas",
     "Max. participants" : "Máx. de participantes",
     "Group …" : "Grupo…",

--- a/l10n/hr.js
+++ b/l10n/hr.js
@@ -109,7 +109,7 @@ OC.L10N.register(
     "admin" : "admin",
     "Share" : "Dijeli",
     "Loading" : "Učitavanje",
-    "You are not allowed to change this option, because this room is shared with you." : "Ne možete mijenjati ovu mogućnost jer soba nije dijeljena s vama.",
+    "You are not allowed to share this room further, because this room is shared with you." : "Ne možete mijenjati ovu mogućnost jer soba nije dijeljena s vama.",
     "Max. rooms" : "Maks. soba",
     "Max. participants" : "Maks. sudionika",
     "Group …" : "Grupa...",

--- a/l10n/hr.json
+++ b/l10n/hr.json
@@ -107,7 +107,7 @@
     "admin" : "admin",
     "Share" : "Dijeli",
     "Loading" : "Učitavanje",
-    "You are not allowed to change this option, because this room is shared with you." : "Ne možete mijenjati ovu mogućnost jer soba nije dijeljena s vama.",
+    "You are not allowed to share this room further, because this room is shared with you." : "Ne možete mijenjati ovu mogućnost jer soba nije dijeljena s vama.",
     "Max. rooms" : "Maks. soba",
     "Max. participants" : "Maks. sudionika",
     "Group …" : "Grupa...",

--- a/l10n/hu.js
+++ b/l10n/hu.js
@@ -115,7 +115,7 @@ OC.L10N.register(
     "admin" : "admin",
     "Share" : "Megosztás",
     "Loading" : "Betöltés",
-    "You are not allowed to change this option, because this room is shared with you." : "Nem módosíthatja ezt a beállítást, mert a szobát megosztják Önnel.",
+    "You are not allowed to share this room further, because this room is shared with you." : "Nem módosíthatja ezt a beállítást, mert a szobát megosztják Önnel.",
     "Max. rooms" : "Szobák legnagyobb száma",
     "Max. participants" : "Részvevők legnagyobb száma",
     "Group …" : "Csoport…",

--- a/l10n/hu.json
+++ b/l10n/hu.json
@@ -113,7 +113,7 @@
     "admin" : "admin",
     "Share" : "Megosztás",
     "Loading" : "Betöltés",
-    "You are not allowed to change this option, because this room is shared with you." : "Nem módosíthatja ezt a beállítást, mert a szobát megosztják Önnel.",
+    "You are not allowed to share this room further, because this room is shared with you." : "Nem módosíthatja ezt a beállítást, mert a szobát megosztják Önnel.",
     "Max. rooms" : "Szobák legnagyobb száma",
     "Max. participants" : "Részvevők legnagyobb száma",
     "Group …" : "Csoport…",

--- a/l10n/it.js
+++ b/l10n/it.js
@@ -115,7 +115,7 @@ OC.L10N.register(
     "admin" : "amministratore",
     "Share" : "Condividi",
     "Loading" : "Caricamento",
-    "You are not allowed to change this option, because this room is shared with you." : "Non ti è consentito modificare questa opzione, poiché questa stanza è condivisa con te.",
+    "You are not allowed to share this room further, because this room is shared with you." : "Non ti è consentito modificare questa opzione, poiché questa stanza è condivisa con te.",
     "Max. rooms" : "Num. massimo stanze",
     "Max. participants" : "Num. massimo partecipanti",
     "Group …" : "Gruppo…",

--- a/l10n/it.json
+++ b/l10n/it.json
@@ -113,7 +113,7 @@
     "admin" : "amministratore",
     "Share" : "Condividi",
     "Loading" : "Caricamento",
-    "You are not allowed to change this option, because this room is shared with you." : "Non ti è consentito modificare questa opzione, poiché questa stanza è condivisa con te.",
+    "You are not allowed to share this room further, because this room is shared with you." : "Non ti è consentito modificare questa opzione, poiché questa stanza è condivisa con te.",
     "Max. rooms" : "Num. massimo stanze",
     "Max. participants" : "Num. massimo partecipanti",
     "Group …" : "Gruppo…",

--- a/l10n/ja.js
+++ b/l10n/ja.js
@@ -115,7 +115,7 @@ OC.L10N.register(
     "admin" : "管理者",
     "Share" : "共有",
     "Loading" : "読み込み中",
-    "You are not allowed to change this option, because this room is shared with you." : "あなたはこの会議室を共有されているため、このオプションを変更する権限がありません。",
+    "You are not allowed to share this room further, because this room is shared with you." : "あなたはこの会議室を共有されているため、このオプションを変更する権限がありません。",
     "Max. rooms" : "最大会議室数",
     "Max. participants" : "最大参加者数",
     "Group …" : "グループ...",

--- a/l10n/ja.json
+++ b/l10n/ja.json
@@ -113,7 +113,7 @@
     "admin" : "管理者",
     "Share" : "共有",
     "Loading" : "読み込み中",
-    "You are not allowed to change this option, because this room is shared with you." : "あなたはこの会議室を共有されているため、このオプションを変更する権限がありません。",
+    "You are not allowed to share this room further, because this room is shared with you." : "あなたはこの会議室を共有されているため、このオプションを変更する権限がありません。",
     "Max. rooms" : "最大会議室数",
     "Max. participants" : "最大参加者数",
     "Group …" : "グループ...",

--- a/l10n/nl.js
+++ b/l10n/nl.js
@@ -114,7 +114,7 @@ OC.L10N.register(
     "admin" : "admin",
     "Share" : "Delen",
     "Loading" : "Laden",
-    "You are not allowed to change this option, because this room is shared with you." : "U mag deze optie niet wijzigen, omdat deze kamer met u wordt gedeeld.",
+    "You are not allowed to share this room further, because this room is shared with you." : "U mag deze optie niet wijzigen, omdat deze kamer met u wordt gedeeld.",
     "Max. rooms" : "Max. ruimtes",
     "Max. participants" : "Max. deelnemers",
     "Group …" : "Groep …",

--- a/l10n/nl.json
+++ b/l10n/nl.json
@@ -112,7 +112,7 @@
     "admin" : "admin",
     "Share" : "Delen",
     "Loading" : "Laden",
-    "You are not allowed to change this option, because this room is shared with you." : "U mag deze optie niet wijzigen, omdat deze kamer met u wordt gedeeld.",
+    "You are not allowed to share this room further, because this room is shared with you." : "U mag deze optie niet wijzigen, omdat deze kamer met u wordt gedeeld.",
     "Max. rooms" : "Max. ruimtes",
     "Max. participants" : "Max. deelnemers",
     "Group …" : "Groep …",

--- a/l10n/pl.js
+++ b/l10n/pl.js
@@ -115,7 +115,7 @@ OC.L10N.register(
     "admin" : "administrator",
     "Share" : "Udostępnij",
     "Loading" : "Wczytywanie",
-    "You are not allowed to change this option, because this room is shared with you." : "Nie możesz zmienić tej opcji, ponieważ ten pokój jest Tobie udostępniony.",
+    "You are not allowed to share this room further, because this room is shared with you." : "Nie możesz zmienić tej opcji, ponieważ ten pokój jest Tobie udostępniony.",
     "Max. rooms" : "Maks. pokoji",
     "Max. participants" : "Maks. uczestników",
     "Group …" : "Grupa…",

--- a/l10n/pl.json
+++ b/l10n/pl.json
@@ -113,7 +113,7 @@
     "admin" : "administrator",
     "Share" : "Udostępnij",
     "Loading" : "Wczytywanie",
-    "You are not allowed to change this option, because this room is shared with you." : "Nie możesz zmienić tej opcji, ponieważ ten pokój jest Tobie udostępniony.",
+    "You are not allowed to share this room further, because this room is shared with you." : "Nie możesz zmienić tej opcji, ponieważ ten pokój jest Tobie udostępniony.",
     "Max. rooms" : "Maks. pokoji",
     "Max. participants" : "Maks. uczestników",
     "Group …" : "Grupa…",

--- a/l10n/pt_BR.js
+++ b/l10n/pt_BR.js
@@ -115,7 +115,7 @@ OC.L10N.register(
     "admin" : "admin",
     "Share" : "Compartilhar",
     "Loading" : "Carregando",
-    "You are not allowed to change this option, because this room is shared with you." : "Você não tem permissão para alterar esta opção, porque esta sala é compartilhada com você.",
+    "You are not allowed to share this room further, because this room is shared with you." : "Você não tem permissão para alterar esta opção, porque esta sala é compartilhada com você.",
     "Max. rooms" : "Máximo de salas",
     "Max. participants" : "Máximo de participantes",
     "Group …" : "Grupo...",

--- a/l10n/pt_BR.json
+++ b/l10n/pt_BR.json
@@ -113,7 +113,7 @@
     "admin" : "admin",
     "Share" : "Compartilhar",
     "Loading" : "Carregando",
-    "You are not allowed to change this option, because this room is shared with you." : "Você não tem permissão para alterar esta opção, porque esta sala é compartilhada com você.",
+    "You are not allowed to share this room further, because this room is shared with you." : "Você não tem permissão para alterar esta opção, porque esta sala é compartilhada com você.",
     "Max. rooms" : "Máximo de salas",
     "Max. participants" : "Máximo de participantes",
     "Group …" : "Grupo...",

--- a/l10n/ru.js
+++ b/l10n/ru.js
@@ -115,7 +115,7 @@ OC.L10N.register(
     "admin" : "администратор",
     "Share" : "Публикация",
     "Loading" : "Загружается",
-    "You are not allowed to change this option, because this room is shared with you." : "Вы не можете изменить эту опцию, потому что эта комната находится в совместном пользовании с вами.",
+    "You are not allowed to share this room further, because this room is shared with you." : "Вы не можете изменить эту опцию, потому что эта комната находится в совместном пользовании с вами.",
     "Max. rooms" : "Макс. количество комнат",
     "Max. participants" : "Макс. количество участников",
     "Group …" : "Группа ...",

--- a/l10n/ru.json
+++ b/l10n/ru.json
@@ -113,7 +113,7 @@
     "admin" : "администратор",
     "Share" : "Публикация",
     "Loading" : "Загружается",
-    "You are not allowed to change this option, because this room is shared with you." : "Вы не можете изменить эту опцию, потому что эта комната находится в совместном пользовании с вами.",
+    "You are not allowed to share this room further, because this room is shared with you." : "Вы не можете изменить эту опцию, потому что эта комната находится в совместном пользовании с вами.",
     "Max. rooms" : "Макс. количество комнат",
     "Max. participants" : "Макс. количество участников",
     "Group …" : "Группа ...",

--- a/l10n/sc.js
+++ b/l10n/sc.js
@@ -111,7 +111,7 @@ OC.L10N.register(
     "admin" : "amministratzione",
     "Share" : "Cumpartzi",
     "Loading" : "Carrighende",
-    "You are not allowed to change this option, because this room is shared with you." : "Non t'est permìtidu de cambiare custa optzione, ca custa istantza est cumpartzida cun tegus.",
+    "You are not allowed to share this room further, because this room is shared with you." : "Non t'est permìtidu de cambiare custa optzione, ca custa istantza est cumpartzida cun tegus.",
     "Max. rooms" : "Màssimu de istantzas",
     "Max. participants" : "Màssimu de partetzipantes",
     "Group …" : "Grupu …",

--- a/l10n/sc.json
+++ b/l10n/sc.json
@@ -109,7 +109,7 @@
     "admin" : "amministratzione",
     "Share" : "Cumpartzi",
     "Loading" : "Carrighende",
-    "You are not allowed to change this option, because this room is shared with you." : "Non t'est permìtidu de cambiare custa optzione, ca custa istantza est cumpartzida cun tegus.",
+    "You are not allowed to share this room further, because this room is shared with you." : "Non t'est permìtidu de cambiare custa optzione, ca custa istantza est cumpartzida cun tegus.",
     "Max. rooms" : "Màssimu de istantzas",
     "Max. participants" : "Màssimu de partetzipantes",
     "Group …" : "Grupu …",

--- a/l10n/sk.js
+++ b/l10n/sk.js
@@ -115,7 +115,7 @@ OC.L10N.register(
     "admin" : "správca",
     "Share" : "Sprístupňovať",
     "Loading" : "Načítava sa...",
-    "You are not allowed to change this option, because this room is shared with you." : "Túto možnosť nemôžete zmeniť, pretože táto miestnosť je s vami zdieľaná.",
+    "You are not allowed to share this room further, because this room is shared with you." : "Túto možnosť nemôžete zmeniť, pretože táto miestnosť je s vami zdieľaná.",
     "Max. rooms" : "Maximálny počet miestností",
     "Max. participants" : "Maximálny počet účastníkov",
     "Group …" : "Skupina ...",

--- a/l10n/sk.json
+++ b/l10n/sk.json
@@ -113,7 +113,7 @@
     "admin" : "správca",
     "Share" : "Sprístupňovať",
     "Loading" : "Načítava sa...",
-    "You are not allowed to change this option, because this room is shared with you." : "Túto možnosť nemôžete zmeniť, pretože táto miestnosť je s vami zdieľaná.",
+    "You are not allowed to share this room further, because this room is shared with you." : "Túto možnosť nemôžete zmeniť, pretože táto miestnosť je s vami zdieľaná.",
     "Max. rooms" : "Maximálny počet miestností",
     "Max. participants" : "Maximálny počet účastníkov",
     "Group …" : "Skupina ...",

--- a/l10n/sl.js
+++ b/l10n/sl.js
@@ -109,7 +109,7 @@ OC.L10N.register(
     "admin" : "skrbnik",
     "Share" : "Souporaba",
     "Loading" : "Poteka nalaganje ...",
-    "You are not allowed to change this option, because this room is shared with you." : "Za spreminjanje te možnosti nimate ustreznih dovoljenj, soba je le v souporabi.",
+    "You are not allowed to share this room further, because this room is shared with you." : "Za spreminjanje te možnosti nimate ustreznih dovoljenj, soba je le v souporabi.",
     "Max. rooms" : "Največ sob",
     "Max. participants" : "Največ udeležencev",
     "Group …" : "Skupina ...",

--- a/l10n/sl.json
+++ b/l10n/sl.json
@@ -107,7 +107,7 @@
     "admin" : "skrbnik",
     "Share" : "Souporaba",
     "Loading" : "Poteka nalaganje ...",
-    "You are not allowed to change this option, because this room is shared with you." : "Za spreminjanje te možnosti nimate ustreznih dovoljenj, soba je le v souporabi.",
+    "You are not allowed to share this room further, because this room is shared with you." : "Za spreminjanje te možnosti nimate ustreznih dovoljenj, soba je le v souporabi.",
     "Max. rooms" : "Največ sob",
     "Max. participants" : "Največ udeležencev",
     "Group …" : "Skupina ...",

--- a/l10n/sr.js
+++ b/l10n/sr.js
@@ -115,7 +115,7 @@ OC.L10N.register(
     "admin" : "админ",
     "Share" : "Подели",
     "Loading" : "Учитавам",
-    "You are not allowed to change this option, because this room is shared with you." : "Није вам дозвољено да измените ову опцију јер се ова соба дели са вама.",
+    "You are not allowed to share this room further, because this room is shared with you." : "Није вам дозвољено да измените ову опцију јер се ова соба дели са вама.",
     "Max. rooms" : "Макс. бр. соба",
     "Max. participants" : "Макс. бр. учесника",
     "Group …" : "Група ...",

--- a/l10n/sr.json
+++ b/l10n/sr.json
@@ -113,7 +113,7 @@
     "admin" : "админ",
     "Share" : "Подели",
     "Loading" : "Учитавам",
-    "You are not allowed to change this option, because this room is shared with you." : "Није вам дозвољено да измените ову опцију јер се ова соба дели са вама.",
+    "You are not allowed to share this room further, because this room is shared with you." : "Није вам дозвољено да измените ову опцију јер се ова соба дели са вама.",
     "Max. rooms" : "Макс. бр. соба",
     "Max. participants" : "Макс. бр. учесника",
     "Group …" : "Група ...",

--- a/l10n/tr.js
+++ b/l10n/tr.js
@@ -115,7 +115,7 @@ OC.L10N.register(
     "admin" : "yönetici",
     "Share" : "Paylaş",
     "Loading" : "Yükleniyor",
-    "You are not allowed to change this option, because this room is shared with you." : "Bu oda sizinle paylaşılmış olduğundan bu ayarı değiştiremezsiniz.",
+    "You are not allowed to share this room further, because this room is shared with you." : "Bu oda sizinle paylaşılmış olduğundan bu ayarı değiştiremezsiniz.",
     "Max. rooms" : "En fazla oda sayısı",
     "Max. participants" : "En fazla katılımcı sayısı",
     "Group …" : "Grup …",

--- a/l10n/tr.json
+++ b/l10n/tr.json
@@ -113,7 +113,7 @@
     "admin" : "yönetici",
     "Share" : "Paylaş",
     "Loading" : "Yükleniyor",
-    "You are not allowed to change this option, because this room is shared with you." : "Bu oda sizinle paylaşılmış olduğundan bu ayarı değiştiremezsiniz.",
+    "You are not allowed to share this room further, because this room is shared with you." : "Bu oda sizinle paylaşılmış olduğundan bu ayarı değiştiremezsiniz.",
     "Max. rooms" : "En fazla oda sayısı",
     "Max. participants" : "En fazla katılımcı sayısı",
     "Group …" : "Grup …",

--- a/l10n/zh_CN.js
+++ b/l10n/zh_CN.js
@@ -113,7 +113,7 @@ OC.L10N.register(
     "admin" : "管理员",
     "Share" : "共享",
     "Loading" : "正在加载",
-    "You are not allowed to change this option, because this room is shared with you." : "你不能更改此选项，因为此房间是与你共享的。",
+    "You are not allowed to share this room further, because this room is shared with you." : "你不能更改此选项，因为此房间是与你共享的。",
     "Max. rooms" : "房间最大数目",
     "Max. participants" : "参与者最大数目",
     "Group …" : "群组 ...",

--- a/l10n/zh_CN.json
+++ b/l10n/zh_CN.json
@@ -111,7 +111,7 @@
     "admin" : "管理员",
     "Share" : "共享",
     "Loading" : "正在加载",
-    "You are not allowed to change this option, because this room is shared with you." : "你不能更改此选项，因为此房间是与你共享的。",
+    "You are not allowed to share this room further, because this room is shared with you." : "你不能更改此选项，因为此房间是与你共享的。",
     "Max. rooms" : "房间最大数目",
     "Max. participants" : "参与者最大数目",
     "Group …" : "群组 ...",

--- a/l10n/zh_HK.js
+++ b/l10n/zh_HK.js
@@ -115,7 +115,7 @@ OC.L10N.register(
     "admin" : "管理員",
     "Share" : "分享",
     "Loading" : "正在載入",
-    "You are not allowed to change this option, because this room is shared with you." : "您無權更改此選項，因為此聊天室是與您分享的。",
+    "You are not allowed to share this room further, because this room is shared with you." : "您無權更改此選項，因為此聊天室是與您分享的。",
     "Max. rooms" : "聊天室數上限",
     "Max. participants" : "參加人數上限",
     "Group …" : "群組……",

--- a/l10n/zh_HK.json
+++ b/l10n/zh_HK.json
@@ -113,7 +113,7 @@
     "admin" : "管理員",
     "Share" : "分享",
     "Loading" : "正在載入",
-    "You are not allowed to change this option, because this room is shared with you." : "您無權更改此選項，因為此聊天室是與您分享的。",
+    "You are not allowed to share this room further, because this room is shared with you." : "您無權更改此選項，因為此聊天室是與您分享的。",
     "Max. rooms" : "聊天室數上限",
     "Max. participants" : "參加人數上限",
     "Group …" : "群組……",

--- a/l10n/zh_TW.js
+++ b/l10n/zh_TW.js
@@ -115,7 +115,7 @@ OC.L10N.register(
     "admin" : "管理員",
     "Share" : "分享",
     "Loading" : "正在載入",
-    "You are not allowed to change this option, because this room is shared with you." : "您不被允許變更此選項，因為此聊天室是與您分享的。",
+    "You are not allowed to share this room further, because this room is shared with you." : "您不被允許變更此選項，因為此聊天室是與您分享的。",
     "Max. rooms" : "最大聊天室",
     "Max. participants" : "最大參與者",
     "Group …" : "群組……",

--- a/l10n/zh_TW.json
+++ b/l10n/zh_TW.json
@@ -113,7 +113,7 @@
     "admin" : "管理員",
     "Share" : "分享",
     "Loading" : "正在載入",
-    "You are not allowed to change this option, because this room is shared with you." : "您不被允許變更此選項，因為此聊天室是與您分享的。",
+    "You are not allowed to share this room further, because this room is shared with you." : "您不被允許變更此選項，因為此聊天室是與您分享的。",
     "Max. rooms" : "最大聊天室",
     "Max. participants" : "最大參與者",
     "Group …" : "群組……",

--- a/ts/Manager/ShareWith.tsx
+++ b/ts/Manager/ShareWith.tsx
@@ -124,7 +124,7 @@ const ShareWith: React.FC<Props> = ({ room, permission, shares: allShares, setSh
 					excluded={{userIds: sharedUserIds, groupIds: sharedGroupIds, circleIds: sharedCircleIds}}
 					shareType={[ShareType.User, ShareType.Group, ShareType.Circle]}/> :
 				<em>
-					<span className="icon icon-details icon-visible"></span> {t('bbb', 'You are not allowed to change this option, because this room is shared with you.')}
+					<span className="icon icon-details icon-visible"></span> {t('bbb', 'You are not allowed to share this room further, because this room is shared with you.')}
 				</em>
 			}
 		</>


### PR DESCRIPTION
`You are not allowed to change this option` can be misinterpreteted as other room options in the dialog.

Since this notice only related to room sharing, it can be clarified to `You are not allowed to share this room further`.


@sualko I adapted EN+DE translations, but how did you translate all the other languages? Is there automatic translation or was this done by volunteers? I don't think I could manually do all translations, please advise :)