### PR TITLE
fix: add notnull to welcome table (#250)

### DIFF
--- a/lib/Migration/Version000000Date20230727145600.php
+++ b/lib/Migration/Version000000Date20230727145600.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\BigBlueButton\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Auto-generated migration step: Please modify to your needs!
+ */
+class Version000000Date20230727145600 extends SimpleMigrationStep {
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+        if ($schema->hasTable('bbb_rooms')) {
+			$table = $schema->getTable('bbb_rooms');
+
+			if ($table->hasColumn('welcome') && $table->getColumn('welcome')->getNotnull()) {
+				$table->getColumn('welcome')->setNotnull(false);
+			}
+		}
+
+		return null;
+	}
+}


### PR DESCRIPTION
The welcome message being `null` in the database does not work well with the frontend. The frontend needs it to be notnull and expects `string`, otherwise throws exceptions.

@sualko I am not familiar with Nextcloud extensions. Is it enough to add another Migration.php by copy&paste&guess? :) I did not find a place where the migrations are referenced.