### PR TITLE
feat(ui): better join button contrast

### DIFF
--- a/ts/Manager/App.scss
+++ b/ts/Manager/App.scss
@@ -152,12 +152,12 @@ pre {
   }
 
   .button.success {
-    background-color: var(--color-success);
-    border-color: var(--color-success-hover);
+    background-color: var(--color-element-success);
+    border-color: var(--color-success-text);
     color: var(--color-primary-text);
 
     &:hover {
-      background-color: var(--color-success-hover);
+      background-color: var(--color-text-success);
     }
   }
 


### PR DESCRIPTION
# Please find below my screen captures done with light theme. 

ℹ️ Also tested with dark theme.

⚠️ In any case, test from reviewer required with light and dark theme before merging

# Old (current) "Join" button

| Normal | Hover |
| --- | --- |
| <img width="253" height="162" alt="old_normal" src="https://github.com/user-attachments/assets/f1a07d37-889c-487c-8c32-3cd6f965bafd" /> | <img width="253" height="162" alt="old_hover" src="https://github.com/user-attachments/assets/4c05530f-988a-4bef-8334-e0943587e107" /> |

# New (commited) "Join" button

| Normal | Hover |
| --- | --- |
| <img width="253" height="162" alt="new_normal" src="https://github.com/user-attachments/assets/4bc758a2-e2f6-4fba-8f2f-11b8a251e523" /> | <img width="253" height="162" alt="new_hover" src="https://github.com/user-attachments/assets/791b9fa1-7567-46f1-a4ff-6da2751997b1" /> |

